### PR TITLE
Add roles declarations to forbid unsafe coercions

### DIFF
--- a/src/Web/XHR/ResponseType.purs
+++ b/src/Web/XHR/ResponseType.purs
@@ -13,6 +13,8 @@ import Data.ArrayBuffer.Types (ArrayBuffer)
 newtype ResponseType :: Type -> Type
 newtype ResponseType res = ResponseType String
 
+type role ResponseType nominal
+
 arrayBuffer :: ResponseType ArrayBuffer
 arrayBuffer = ResponseType "arraybuffer"
 


### PR DESCRIPTION
This prevents terms of type `ResponseType a` to be coerced to type `ResponseType b`. The reasoning being that the runtime value of two arbitrary response types may differ.