### PR TITLE
fromFormElement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Breaking changes:
 
 New features:
 - Added roles declarations to forbid unsafe coercions (#7) 
+- Can create a new `FormData` from `HTMLFormElement` (#15)
 
 Bugfixes:
 - Access the "timeout" property instead of "statusText" in `timeout` (#12)

--- a/bower.json
+++ b/bower.json
@@ -20,6 +20,7 @@
     "purescript-datetime": "master",
     "purescript-http-methods": "main",
     "purescript-web-dom": "master",
-    "purescript-web-file": "master"
+    "purescript-web-file": "master",
+    "purescript-web-html": "master"
   }
 }

--- a/src/Web/XHR/FormData.js
+++ b/src/Web/XHR/FormData.js
@@ -4,6 +4,10 @@ exports["new"] = function () {
   return new FormData();
 };
 
+exports._fromFormElement = function(form) {
+  return new FormData(form);
+};
+
 exports._append = function (name, value, fd) {
   fd.append(name, value);
 };

--- a/src/Web/XHR/FormData.purs
+++ b/src/Web/XHR/FormData.purs
@@ -19,6 +19,7 @@ import Data.Nullable (Nullable, toNullable)
 import Effect (Effect)
 import Effect.Uncurried as Fn
 import Web.File.Blob (Blob)
+import Web.HTML.HTMLFormElement (HTMLFormElement)
 
 foreign import data FormData :: Type
 
@@ -35,6 +36,9 @@ derive newtype instance ordFileName :: Ord FileName
 derive instance newtypeFileName :: Newtype FileName _
 
 foreign import new :: Effect FormData
+
+fromFormElement :: HTMLFormElement -> Effect FormData
+fromFormElement formElement = Fn.runEffectFn1 _fromFormElement formElement
 
 append :: EntryName -> String -> FormData -> Effect Unit
 append name value fd = Fn.runEffectFn3 _append name value fd
@@ -53,6 +57,8 @@ set name value fd = Fn.runEffectFn3 _set name value fd
 
 setBlob :: EntryName -> Blob -> Maybe FileName -> FormData -> Effect Unit
 setBlob name value filename fd = Fn.runEffectFn4 _setBlob name value (toNullable filename) fd
+
+foreign import _fromFormElement :: Fn.EffectFn1 HTMLFormElement FormData
 
 -- void append(USVString name, USVString value);
 foreign import _append :: Fn.EffectFn3 EntryName String FormData Unit


### PR DESCRIPTION
**Description of the change**

https://xhr.spec.whatwg.org/#dom-formdata

It's really annoying not having a way to get `FormData` for `Affjax` despite having an `HTMLFormElement`.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
