### PR TITLE
Do not pass `filename == null` to `FileData.append`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Breaking changes:
 New features:
 
 Bugfixes:
+- Passing `Nothing` for the `filename` parameter to `appendBlob` and `setBlob`
+  has the effect of using the filename from the `File` object, rather than
+  making filename equal to `"null"`.
 
 Other improvements:
 
@@ -37,7 +40,7 @@ Breaking changes:
 - Added support for PureScript 0.14 and dropped support for all previous versions (#10)
 
 New features:
-- Added roles declarations to forbid unsafe coercions (#7) 
+- Added roles declarations to forbid unsafe coercions (#7)
 - Can create a new `FormData` from `HTMLFormElement` (#15)
 
 Bugfixes:

--- a/src/Web/XHR/FormData.js
+++ b/src/Web/XHR/FormData.js
@@ -12,7 +12,7 @@ export function _append(name, value, fd) {
 }
 
 export function _appendBlob(name, value, filename, fd) {
-  fd.append(name, value, filename);
+  fd.append(name, value, filename === null ? undefined : filename);
 }
 
 export function _delete(name, fd) {
@@ -28,5 +28,5 @@ export function _set(name, value, fd) {
 }
 
 export function _setBlob(name, value, filename, fd) {
-  fd.set(name, value, filename);
+  fd.set(name, value, filename === null ? undefined : filename);
 }


### PR DESCRIPTION
**Description of the change**

When calling `appendBlob` or `setBlob`, passing `Nothing` for the `filename` parameter translates into calling `fd.append(_, _, null)`, which has the effect of setting filename to `"null"` (at least on Chromium and FireFox), rather than the intended behavior of getting the filename from the `File` object.

This change makes it so that `Nothing` on PureScript side translates to `undefined` on JS side, which works as expected.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- ~[ ] Linked any existing issues or proposals that this pull request should close~
- ~[ ] Updated or added relevant documentation~
- ~[ ] Added a test for the contribution (if applicable)~
